### PR TITLE
Fix "Double block fails" bug in unsubscribe flow

### DIFF
--- a/src/sidebar/utils/unsubscribeFlow.tsx
+++ b/src/sidebar/utils/unsubscribeFlow.tsx
@@ -57,7 +57,9 @@ export function useUnsubscribeFlow(
     if (blockSenders) {
       setModal({ action: "unsubscribe", type: "pending", subtype: "blocking" });
       for (const email of Object.keys(selectedSenders)) {
-        await blockSender(email);
+        if (!noUnsubscribeOptionSenders.includes(email)) {
+          await blockSender(email);
+        }
       }
     }
 


### PR DESCRIPTION
This commit resolves a bug where the application would attempt to block a sender twice if they had no automatic unsubscribe link.

The issue occurred because:
1.  The user selects a sender and the "block" option.
2.  The application presents a modal to manually handle senders without an unsubscribe link, where the user can choose to block them (first block).
3.  At the end of the process, a final loop would re-attempt to block all initially selected senders (second block), causing a failure.

The fix adds a conditional check in the `endUnsubscribeFlow` function to skip the final block action for any sender that was already handled and blocked in the preceding modal flow.