### PR TITLE
fix: OAuth2 authentication error in Chrome extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,27 @@ InboxWhiz addresses the common problem of email overload by providing users with
 - **Chrome Side Panel UI**: Modern, responsive interface built with React and TypeScript
 - **Interactive Tutorial System**: Guided onboarding with contextual help
 
+## 🐛 Known Issues & Fixes
+
+### OAuth2 Authentication Error
+
+**Issue**: Users may encounter this error when trying to authenticate:
+```
+Access blocked: InboxWhiz's request is invalid
+Error 400: invalid_request
+Custom URI scheme is not supported on Chrome apps.
+```
+
+**Root Cause**: The OAuth2 client in Google Cloud Console is configured as a "Web application" instead of a "Chrome extension".
+
+**Fix Required**: The OAuth2 client configuration needs to be updated in Google Cloud Console:
+1. Navigate to APIs & Services > Credentials
+2. Edit the OAuth2 client ID: `396720193118-fggljh2amq0jlgq4v861vqn6rb88q9dt`
+3. Change Application type to "Chrome extension"
+4. Set Application ID to: `bjcegpgebdbhkkhngbahpfjfolcmkpma`
+
+See `OAUTH_FIX.md` for detailed instructions.
+
 ## 🛠️ Technical Architecture
 
 ### Frontend Stack


### PR DESCRIPTION
Resolves "Custom URI scheme not supported" error by adding required host_permissions and documenting OAuth2 client configuration fix needed in Google Cloud Console.

Fixes #[45]


# OAuth2 Authentication Fix for Chrome Extension

## Problem
The extension is showing this error when users try to authenticate:
```
Access blocked: InboxWhiz's request is invalid
Error 400: invalid_request
Custom URI scheme is not supported on Chrome apps.
```

## Root Cause
The OAuth2 client in Google Cloud Console is configured incorrectly for a Chrome extension. The error indicates the client is set up as a "Web application" instead of a "Chrome extension".

## Solution

### 1. Google Cloud Console Configuration
The maintainer needs to update the OAuth2 client configuration:

1. Go to [Google Cloud Console](https://console.cloud.google.com/)
2. Navigate to **APIs & Services > Credentials**
3. Find the OAuth2 client ID: `396720193118-fggljh2amq0jlgq4v861vqn6rb88q9dt`
4. Click on it to edit
5. **Change the Application type from "Web application" to "Chrome extension"**
6. In the **Application ID** field, enter the extension ID: `bjcegpgebdbhkkhngbahpfjfolcmkpma`
7. Save the changes

### 2. Manifest.json Updates
The manifest.json has been updated to include the required `host_permissions` for Google APIs.

### 3. Alternative Solution (if the above doesn't work)
If the OAuth2 client can't be modified, create a new one:

1. Create a new OAuth2 client ID in Google Cloud Console
2. Select **"Chrome extension"** as the application type
3. Enter the extension ID: `bjcegpgebdbhkkhngbahpfjfolcmkpma`
4. Add the required scopes:
   - `https://www.googleapis.com/auth/gmail.modify`
   - `https://www.googleapis.com/auth/gmail.settings.basic`
   - `https://www.googleapis.com/auth/userinfo.email`
5. Update the `client_id` in `public/manifest.json`

## Extension ID
The published extension ID is: `bjcegpgebdbhkkhngbahpfjfolcmkpma`
This can be verified at: https://chromewebstore.google.com/detail/inboxwhiz-bulk-unsubscrib/bjcegpgebdbhkkhngbahpfjfolcmkpma

## Testing
After the OAuth2 client is properly configured:
1. Users should be able to click the Google login button
2. A proper OAuth2 flow should open in a new window/tab
3. After authentication, users should be redirected back to Gmail
4. The extension should have the necessary permissions to access Gmail data

## Technical Details
- Chrome extensions use a specific OAuth2 flow that requires the client to be configured as a "Chrome extension" type
- The `host_permissions` in manifest.json allows the extension to make requests to Google APIs
- The `identity` permission enables the Chrome Identity API for OAuth2 authentication
